### PR TITLE
Update node annotations for multi-networking

### DIFF
--- a/pkg/controller/nodeipam/ipam/BUILD
+++ b/pkg/controller/nodeipam/ipam/BUILD
@@ -25,6 +25,7 @@ go_library(
         "//vendor/google.golang.org/api/compute/v1:compute",
         "//vendor/k8s.io/api/core/v1:core",
         "//vendor/k8s.io/apimachinery/pkg/api/errors",
+        "//vendor/k8s.io/apimachinery/pkg/api/resource",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:meta",
         "//vendor/k8s.io/apimachinery/pkg/fields",
         "//vendor/k8s.io/apimachinery/pkg/labels",

--- a/pkg/controller/nodeipam/ipam/cloud_cidr_allocator.go
+++ b/pkg/controller/nodeipam/ipam/cloud_cidr_allocator.go
@@ -20,9 +20,13 @@ limitations under the License.
 package ipam
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
+	"math"
 	"math/rand"
 	"net"
+	"strings"
 	"sync"
 	"time"
 
@@ -31,6 +35,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -327,7 +332,9 @@ func (ca *cloudCIDRAllocator) updateCIDRAllocation(nodeName string) error {
 	}
 
 	if northInterfaces != nil || additionalNodeNetworks != nil {
-		// TODO: perform IP capacity and annotation updates
+		if err := ca.updateMultiNetworkAnnotations(node, northInterfaces, additionalNodeNetworks); err != nil {
+			return err
+		}
 	}
 	err = utilnode.SetNodeCondition(ca.client, types.NodeName(node.Name), v1.NodeCondition{
 		Type:               v1.NodeNetworkUnavailable,
@@ -384,4 +391,82 @@ func (ca *cloudCIDRAllocator) ReleaseCIDR(node *v1.Node) error {
 	klog.V(2).Infof("Node %v PodCIDR (%v) will be released by external cloud provider (not managed by controller)",
 		node.Name, node.Spec.PodCIDR)
 	return nil
+}
+
+func (ca *cloudCIDRAllocator) updateMultiNetworkAnnotations(node *v1.Node, northInterfaces networkv1.NorthInterfacesAnnotation, additionalNodeNetworks networkv1.MultiNetworkAnnotation) error {
+	northInterfaceAnn, err := networkv1.MarshalNorthInterfacesAnnotation(northInterfaces)
+	if err != nil {
+		klog.ErrorS(err, "Failed to marshal the north interfaces annotation for multi-networking", "nodeName", node.Name)
+		return err
+	}
+	additionalNodeNwAnn, err := networkv1.MarshalAnnotation(additionalNodeNetworks)
+	if err != nil {
+		klog.ErrorS(err, "Failed to marshal the additional node networks annotation for multi-networking", "nodeName", node.Name)
+		return err
+	}
+	if node.Annotations == nil {
+		node.Annotations = make(map[string]string)
+	}
+	node.Annotations[networkv1.NorthInterfacesAnnotationKey] = northInterfaceAnn
+	node.Annotations[networkv1.MultiNetworkAnnotationKey] = additionalNodeNwAnn
+	node.Status.Capacity, err = allocateIPCapacity(node, additionalNodeNetworks)
+	if err != nil {
+		return err
+	}
+	// Prepare patch bytes for the node update.
+	patchBytes, err := json.Marshal([]interface{}{
+		map[string]interface{}{
+			"op":    "replace",
+			"path":  "/metadata/annotations",
+			"value": node.Annotations,
+		},
+		map[string]interface{}{
+			"op":    "add",
+			"path":  "/status/capacity",
+			"value": node.Status.Capacity,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to build patch bytes for multi-networking: %v", err)
+	}
+	if _, err = ca.client.CoreV1().Nodes().Patch(context.TODO(), node.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{}, "status"); err != nil {
+		nodeutil.RecordNodeStatusChange(ca.recorder, node, "CIDRAssignmentFailed")
+		klog.ErrorS(err, "Failed to update the node annotations and capacity for multi-networking", "nodeName", node.Name)
+		return err
+	}
+	return nil
+}
+
+// allocateIPCapacity updates the extended IP resource capacity for every non-default network on the node.
+func allocateIPCapacity(node *v1.Node, nodeNetworks networkv1.MultiNetworkAnnotation) (v1.ResourceList, error) {
+	resourceList := node.Status.Capacity
+	if resourceList == nil {
+		resourceList = make(v1.ResourceList)
+	}
+	// Rebuild the IP capacity for all the networks on the node by deleting the existing IP capacities first.
+	for name := range resourceList {
+		if strings.HasPrefix(name.String(), networkv1.NetworkResourceKeyPrefix) {
+			delete(resourceList, name)
+		}
+	}
+	for _, nw := range nodeNetworks {
+		_, ipNet, err := net.ParseCIDR(nw.Cidrs[0])
+		if err != nil {
+			return nil, err
+		}
+		// TODO: Modify this when IPv6 is supported
+		maxBits := 32
+		ones, _ := ipNet.Mask.Size()
+		ipCount := maxNumberOfIPs(ones, maxBits)
+		resourceList[v1.ResourceName(networkv1.NetworkResourceKeyPrefix+nw.Name+".IP")] = *resource.NewQuantity(int64(ipCount), resource.DecimalSI)
+	}
+	return resourceList, nil
+}
+
+// maxNumberOfIPs returns the number of IPs supported on a single network. The number of IPs supported are halved and returned for overprovisioning purposes.
+func maxNumberOfIPs(perNodeMaskSize, maxBits int) int {
+	if perNodeMaskSize == maxBits {
+		return 1
+	}
+	return int((math.Pow(float64(2), float64(maxBits-perNodeMaskSize)))) >> 1
 }

--- a/pkg/controller/nodeipam/ipam/cloud_cidr_allocator_test.go
+++ b/pkg/controller/nodeipam/ipam/cloud_cidr_allocator_test.go
@@ -28,6 +28,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
+	networkv1 "k8s.io/cloud-provider-gcp/crd/apis/network/v1"
+	"k8s.io/cloud-provider-gcp/pkg/controller/testutil"
 	netutils "k8s.io/utils/net"
 )
 
@@ -186,5 +188,114 @@ func TestNeedPodCIDRsUpdate(t *testing.T) {
 				t.Errorf("got: %v, want: %v", got, tc.want)
 			}
 		})
+	}
+}
+
+type multiNetworkTestCase struct {
+	description            string
+	fakeNodeHandler        *testutil.FakeNodeHandler
+	northInterfaces        networkv1.NorthInterfacesAnnotation
+	additionalNodeNetworks networkv1.MultiNetworkAnnotation
+	expectedIPCapacities   map[string]int64
+}
+
+func TestUpdateMultiNetworkAnnotations(t *testing.T) {
+	testCases := []multiNetworkTestCase{
+		{
+			description: "node with no additional networks",
+			fakeNodeHandler: &testutil.FakeNodeHandler{
+				Existing: []*v1.Node{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "node0",
+							Labels: map[string]string{
+								"testLabel-0": "node0",
+							},
+						},
+					},
+				},
+				Clientset: fake.NewSimpleClientset(),
+			},			
+		},
+		{
+			description: "node with 2 additional networks",
+			fakeNodeHandler: &testutil.FakeNodeHandler{
+				Existing: []*v1.Node{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "node0",
+							Labels: map[string]string{
+								"testLabel-0": "node0",
+							},
+						},
+					},
+				},
+				Clientset: fake.NewSimpleClientset(),
+			},
+			northInterfaces: []networkv1.NorthInterface{
+				{
+					Network:   "Blue-Network",
+					IpAddress: "172.10.0.1",
+				},
+				{
+					Network:   "Red-Network",
+					IpAddress: "10.10.0.1",
+				},
+			},
+			additionalNodeNetworks: []networkv1.NodeNetwork{
+				{
+					Name:  "Blue-Network",
+					Cidrs: []string{"30.20.10.0/24"},
+					Scope: "host-local",
+				},
+				{
+					Name:  "Red-Network",
+					Cidrs: []string{"10.20.30.0/24"},
+					Scope: "host-local",
+				},
+			},
+			expectedIPCapacities: map[string]int64{
+				networkv1.NetworkResourceKeyPrefix + "Red-Network.IP":  128,
+				networkv1.NetworkResourceKeyPrefix + "Blue-Network.IP": 128,
+			},
+		},
+	}
+	// test function
+	testFunc := func(tc multiNetworkTestCase) {
+		for _, node := range tc.fakeNodeHandler.Existing {
+			ca := &cloudCIDRAllocator{
+				client: tc.fakeNodeHandler,
+			}
+			if err := ca.updateMultiNetworkAnnotations(node, tc.northInterfaces, tc.additionalNodeNetworks); err != nil {
+				t.Errorf("%v: unexpected error in updateMultiNetworkAnnotations: %v", tc.description, err)
+			}
+		}
+		for _, updatedNode := range tc.fakeNodeHandler.GetUpdatedNodesCopy() {
+			expectedNorthInterfaceAnnotation, _ := networkv1.MarshalNorthInterfacesAnnotation(tc.northInterfaces)
+			a, ok := updatedNode.ObjectMeta.Annotations[networkv1.NorthInterfacesAnnotationKey]
+			if a != expectedNorthInterfaceAnnotation || !ok {
+				t.Errorf("%v: incorrect north-interface annotation on the node, got: %s, want: %s", tc.description, a, expectedNorthInterfaceAnnotation)
+			}
+			expectedMultiNetworkAnnotation, _ := networkv1.MarshalAnnotation(tc.additionalNodeNetworks)
+			a, ok = updatedNode.ObjectMeta.Annotations[networkv1.MultiNetworkAnnotationKey]
+			if a != expectedMultiNetworkAnnotation || !ok {
+				t.Errorf("%v: incorrect multinetwork annotation on the node, got: %s, want: %s", tc.description, a, expectedMultiNetworkAnnotation)
+			}			
+			gotCapacities := updatedNode.Status.Capacity
+			if len(gotCapacities) != len(tc.expectedIPCapacities) {
+				t.Errorf("%s: incorrect capacities on the node status, got: %v, want: %v", tc.description, gotCapacities, tc.expectedIPCapacities)
+			}
+			for k, v := range tc.expectedIPCapacities {
+				q, ok := gotCapacities[v1.ResourceName(k)]				
+				if !ok || v != q.Value() {
+					t.Errorf("%v: incorrect IP capacity for network %s on the node, got: %v, want: %v", tc.description, k, q.Value(), v)
+				}
+			}
+		}
+	}
+
+	// run the test cases
+	for _, tc := range testCases {
+		testFunc(tc)
 	}
 }


### PR DESCRIPTION
This PR updates the node with per-network IP capacity, north-interface and additional-networks annotations required for multi-networking.